### PR TITLE
Improve evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ Thumbs.db
 # Session cookies — never commit these, they grant account access
 cookies.env
 curl-cmd.txt
+
+# Project specific dirs to exclude
+/copied_from_t0_rcp
+/evaluate/evaluations
+/evaluate/html_dumps

--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,9 @@ Thumbs.db
 cookies.env
 curl-cmd.txt
 
-# Project specific dirs to exclude
+# Project specific dirs and file to exclude
 /copied_from_t0_rcp
 /evaluate/evaluations
 /evaluate/html_dumps
+/evaluate/ground_truth
+/evaluate/evaluate_llm_options.html

--- a/evaluate/evaluate_llm_options.qmd
+++ b/evaluate/evaluate_llm_options.qmd
@@ -1,0 +1,216 @@
+---
+title: "RCPond LLM Evaluation"
+format:
+  html:
+    toc: true
+    code-fold: true
+    self-contained: true
+    page-layout: full
+execute:
+  warning: false
+---
+
+## Rendering
+
+To render this file, in a shell, use the following commands:
+
+```bash
+cd evaluate
+uv run --with scikit-learn --with matplotlib --with jupyter --with nbformat quarto render evaluate_llm_options.qmd
+```
+
+## Parameters
+
+
+Edit these values to compare different evaluation runs or models.
+
+```{python}
+# Path to the JSON results file produced by `rcpond evaluate-all`.
+# Format: dict[ticket_number, list[LLMResponse]]
+results_file = "evaluations/html_download/gpt-4o_3runs.json"
+
+# Path to the ground truth CSV
+ground_truth_file = "ground_truth/ground_truth.csv"
+
+# Model label for titles/tables. Set to None to read from the JSON.
+llm_model_override = None  # e.g. "gpt-4o"
+
+# Mapping from email template filename to ground truth label.
+# Extend this dict as new templates are added.
+# Note that the old `t0-rcp` repo included an action `SEND_TO_DSG_TEAM`. There is no
+# cases in the ground truth, nor is there a jinja template for this, hence it is
+# excluded in the dict below.
+TEMPLATE_TO_LABEL: dict[str, str] = {
+    "approve.yaml.j2":                  "APPROVE",
+    "check_with_rcp.yaml.j2":           "CHECK_WITH_RCP",
+    "send_back_to_submitter.yaml.j2":   "SEND_BACK_TO_SUBMITTER",
+    "send_to_it.yaml.j2":               "SEND_TO_IT",
+    "send_to_pmu.yaml.j2":              "SEND_TO_PMU",
+    "send_to_rc_lead.yaml.j2":          "SEND_TO_RC_LEAD",
+    "send_to_rcp.yaml.j2":              "SEND_TO_RCP",
+    "send_to_rcwg.yaml.j2":             "SEND_TO_RCWG",
+}
+
+# Label used when the LLM made no tool call
+NO_ACTION_LABEL = "NO_ACTION"
+```
+
+```{python}
+import json
+from collections import Counter
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from sklearn.metrics import ConfusionMatrixDisplay, confusion_matrix
+
+# ---------------------------------------------------------------------------
+# Load results: dict[ticket_number, list[LLMResponse]]
+# ---------------------------------------------------------------------------
+with Path(results_file).open() as f:
+    results: dict[str, list[dict]] = json.load(f)
+
+# ---------------------------------------------------------------------------
+# Derive model name and run count
+# ---------------------------------------------------------------------------
+first_response = next((runs[0] for runs in results.values() if runs), None)
+llm_model = llm_model_override or (first_response or {}).get("llm_model") or "unknown"
+num_runs = max((len(v) for v in results.values()), default=1)
+
+print(f"Model:   {llm_model}")
+print(f"Tickets: {len(results)}")
+print(f"Runs:    {num_runs}")
+```
+
+```{python}
+# ---------------------------------------------------------------------------
+# Load ground truth — filtered to tickets present in results
+# ---------------------------------------------------------------------------
+gt = pd.read_csv(ground_truth_file)
+gt.columns = gt.columns.str.strip()
+gt["ticket_number"] = gt["ticket_number"].str.strip()
+gt["answer"] = gt["answer"].str.strip()
+
+gt_filtered = gt[gt["ticket_number"].isin(results.keys())].copy()
+print(f"Ground truth rows matched: {len(gt_filtered)} / {len(results)} tickets")
+```
+
+## Per-ticket results
+
+Each row shows the ground truth label and the prediction for each run.
+Green = correct, red = incorrect.
+
+```{python}
+def _predicted_label(response: dict) -> str:
+    tc = response.get("planned_tool_call")
+    if not tc:
+        return NO_ACTION_LABEL
+    template = tc["function"]["arguments"].get("template_name", "")
+    return TEMPLATE_TO_LABEL.get(template, f"UNKNOWN:{template}")
+
+
+rows = []
+for _, gt_row in gt_filtered.iterrows():
+    ticket = gt_row["ticket_number"]
+    gt_label = gt_row["answer"]
+    notes = gt_row.get("notes", "")
+    predictions = [_predicted_label(r) for r in results.get(ticket, [])]
+
+    row = {"ticket_number": ticket, "ground_truth": gt_label, "notes": notes}
+    for i, pred in enumerate(predictions):
+        row[f"run_{i + 1}"] = pred
+        row[f"correct_{i + 1}"] = pred == gt_label
+
+    rows.append(row)
+
+detail_df = pd.DataFrame(rows)
+run_cols = [c for c in detail_df.columns if c.startswith("run_")]
+correct_cols = [c for c in detail_df.columns if c.startswith("correct_")]
+
+
+def _highlight(row):
+    styles = [""] * len(row)
+    for run_col in run_cols:
+        if run_col in row.index:
+            correct = row[run_col] == row["ground_truth"]
+            idx = list(row.index).index(run_col)
+            styles[idx] = "background-color: #d4edda" if correct else "background-color: #f8d7da"
+    return styles
+
+
+(
+    detail_df[["ticket_number", "ground_truth"] + run_cols]
+    .style.apply(_highlight, axis=1)
+    .set_table_styles([{"selector": "table", "props": [("width", "100%")]}])
+)
+```
+
+## Accuracy summary
+
+```{python}
+summary_rows = []
+for i, run_col in enumerate(run_cols):
+    correct_col = f"correct_{i + 1}"
+    n_correct = int(detail_df[correct_col].sum())
+    n_total = len(detail_df)
+    summary_rows.append({
+        "run": f"Run {i + 1}",
+        "correct": n_correct,
+        "total": n_total,
+        "accuracy": f"{n_correct / n_total:.1%}" if n_total else "—",
+    })
+
+print(f"Model: {llm_model}")
+pd.DataFrame(summary_rows)
+```
+
+```{python}
+# Majority-vote accuracy (most common prediction per ticket wins ties randomly)
+if num_runs > 1:
+    majority_correct = 0
+    for _, row in detail_df.iterrows():
+        predictions = [row[c] for c in run_cols]
+        majority_pred = Counter(predictions).most_common(1)[0][0]
+        if majority_pred == row["ground_truth"]:
+            majority_correct += 1
+
+    n = len(detail_df)
+    print(f"Majority-vote accuracy ({num_runs} runs): {majority_correct}/{n} = {majority_correct/n:.1%}")
+```
+
+## Per-label breakdown
+
+How often each label appears in the ground truth vs. the model's predictions.
+
+```{python}
+# Use majority prediction when multiple runs, otherwise run 1
+if num_runs > 1:
+    detail_df["prediction"] = detail_df.apply(
+        lambda row: Counter([row[c] for c in run_cols]).most_common(1)[0][0], axis=1
+    )
+else:
+    detail_df["prediction"] = detail_df["run_1"]
+
+all_labels = sorted(set(detail_df["ground_truth"]) | set(detail_df["prediction"]))
+
+pd.DataFrame([
+    {
+        "label": label,
+        "ground_truth_count": int((detail_df["ground_truth"] == label).sum()),
+        "predicted_count": int((detail_df["prediction"] == label).sum()),
+    }
+    for label in all_labels
+])
+```
+
+## Confusion matrix
+
+```{python}
+labels = sorted(set(detail_df["ground_truth"]) | set(detail_df["prediction"]))
+cm = confusion_matrix(detail_df["ground_truth"], detail_df["prediction"], labels=labels)
+fig, ax = plt.subplots(figsize=(max(6, len(labels)), max(5, len(labels) - 1)))
+ConfusionMatrixDisplay(cm, display_labels=labels).plot(ax=ax, xticks_rotation=90, colorbar=False)
+ax.set_title(f"Confusion matrix — {llm_model}")
+plt.tight_layout()
+plt.show()
+```

--- a/evaluate/readme.md
+++ b/evaluate/readme.md
@@ -1,0 +1,1 @@
+The `evaluate` directory contains the code for evaluating RCPond on a set of ground-truthed test cases. The code here is not part of the core RCPond package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,13 @@ flake8-unused-arguments.ignore-variadic-names = true  # allow unused *args/**kwa
 
 [dependency-groups]
 dev = [
+    "beautifulsoup4>=4.12",
+    "pandas>=2.0",
     "pandas-stubs>=2.0",
     "pdoc>=16.0.0",
     "pre-commit",
     "pytest >=6",
     "pytest-cov >=3",
     "types-beautifulsoup4>=4.12",
+    "types-requests>=2.32",
 ]

--- a/src/rcpond/cli.py
+++ b/src/rcpond/cli.py
@@ -120,7 +120,7 @@ try:
     def evaluate_all(
         ctx: typer.Context,
         in_dir: Annotated[Path, typer.Argument(help="Directory of pre-downloaded HTML ticket files.")],
-        out_file: Annotated[Path, typer.Argument(help="Output CSV file path (must not already exist).")],
+        out_file: Annotated[Path, typer.Argument(help="Output JSON file path (must not already exist).")],
     ):
         """Evaluate LLM performance against a directory of pre-downloaded HTML tickets."""
         if not out_file.parent.exists():

--- a/src/rcpond/cli.py
+++ b/src/rcpond/cli.py
@@ -120,18 +120,28 @@ try:
     def evaluate_all(
         ctx: typer.Context,
         in_dir: Annotated[Path, typer.Argument(help="Directory of pre-downloaded HTML ticket files.")],
-        out_file: Annotated[Path, typer.Argument(help="Output JSON file path (must not already exist).")],
+        out_dir: Annotated[Path, typer.Argument(help="Directory to write the JSON results file.")],
+        num_runs: Annotated[int, typer.Option(help="Number of LLM runs per ticket (for majority-vote analysis).")] = 1,
     ):
-        """Evaluate LLM performance against a directory of pre-downloaded HTML tickets."""
-        if not out_file.parent.exists():
-            msg = f"Output directory does not exist: {out_file.parent}"
-            raise typer.BadParameter(msg, param_hint="out_file")
+        """Evaluate LLM performance against a directory of pre-downloaded HTML tickets.
+
+        The output filename is derived from the configured LLM model name and the
+        number of runs, e.g. ``gpt-4o_3runs.json``.
+        """
+        if not out_dir.exists():
+            msg = f"Output directory does not exist: {out_dir}"
+            raise typer.BadParameter(msg, param_hint="out_dir")
+
+        config = _config(ctx)
+        ## Sanitise model name for use in a filename (replace / and : which appear in some model IDs)
+        safe_model = config.llm_model.replace("/", "-").replace(":", "-")
+        out_file = out_dir / f"{safe_model}_{num_runs}runs.json"
 
         if out_file.exists():
-            msg = f"Output file already exists: {out_file}"
-            raise typer.BadParameter(msg, param_hint="out_file")
+            msg = f"Output file already exists: {out_file}. Delete it or choose a different output directory."
+            raise typer.BadParameter(msg, param_hint="out_dir")
 
-        command.batch_evaluate_tickets(in_dir=in_dir, out_file=out_file, config=_config(ctx))
+        command.batch_evaluate_tickets(in_dir=in_dir, out_file=out_file, num_runs=num_runs, config=config)
 
 except ImportError:
     pass

--- a/src/rcpond/command.py
+++ b/src/rcpond/command.py
@@ -55,7 +55,9 @@ def _process_ticket(ticket: Ticket, dry_run: bool, config: Config, service_now: 
     print(f"{full_ticket=}")
     tools = get_available_tools(config)
     system_prompt, user_prompt = construct_prompt(full_ticket, config)
-    llm_response: LLMResponse = llm.generate(system_prompt, user_prompt, config.llm_model, tools=tools)
+    llm_response: LLMResponse = llm.generate(
+        system_prompt, user_prompt, config.llm_model, tools=tools, ticket_number=ticket.number
+    )
     print(f"{llm_response=}")
 
     if not dry_run and llm_response.planned_tool_call is not None:
@@ -153,10 +155,13 @@ def batch_process_tickets(dry_run: bool, config: Config | None = None):
         _ = _process_ticket(ticket, dry_run, config, service_now, llm)
 
 
-def batch_evaluate_tickets(in_dir: Path, out_file: Path, config: Config | None = None):
-    """Process all tickets in an offline html-based directory of ServiceNow tickets.
+def batch_evaluate_tickets(in_dir: Path, out_file: Path, num_runs: int = 1, config: Config | None = None):
+    """Process all Azure tickets in an offline HTML directory, across multiple runs.
 
-    Used for evaluating the performance of the LLM in reviewing tickets.
+    Used for evaluating the performance of the LLM in reviewing tickets. Results
+    are written as ``dict[str, list[LLMResponse]]`` keyed by ticket number, so
+    that each ticket's responses across all runs are grouped together. Non-Azure
+    tickets are skipped.
 
     Parameters
     ----------
@@ -164,6 +169,8 @@ def batch_evaluate_tickets(in_dir: Path, out_file: Path, config: Config | None =
         Directory containing pre-downloaded HTML ticket files.
     out_file : Path
         Path to write the JSON results. Must not already exist.
+    num_runs : int
+        Number of times to run the LLM over all tickets (for majority-vote analysis).
     config : Config | None
         Configuration to use. If None, Config() is constructed from the environment.
     """
@@ -176,24 +183,27 @@ def batch_evaluate_tickets(in_dir: Path, out_file: Path, config: Config | None =
     config = config or Config()
     service_now: HtmlServiceNow = HtmlServiceNow(in_dir)
     llm: LLM = LLM(config)
-    all_responses: list[LLMResponse] = []
-    print("DEBUG: service_now.get_tickets(include_assigned_tickets=True)")
-    all_tickets = service_now.get_tickets(include_assigned_tickets=True)
-    for ticket in all_tickets:
-        # print(f"{ticket=}")
 
+    ## Pre-filter to Azure tickets only
+    all_tickets = service_now.get_tickets(include_assigned_tickets=True)
+    azure_tickets = []
+    for ticket in all_tickets:
         # TODO: Temporary, an messy way to limit tickets to only those related to Azure
         # Find a better solution
         full_ticket = service_now.get_full_ticket(ticket)
         if full_ticket.which_service != "Azure":
             print(f"skipping non-Azure ticket: {ticket.number}")
-            print()
-            continue
+        else:
+            azure_tickets.append(ticket)
 
-        resp = _process_ticket(ticket=ticket, dry_run=True, config=config, service_now=service_now, llm=llm)
-        all_responses.append(resp)
-        # print(f"{resp=}")
-        print()
+    ## Run the LLM num_runs times, accumulating responses per ticket
+    results: dict[str, list[LLMResponse]] = {t.number: [] for t in azure_tickets}
+    for run in range(num_runs):
+        print(f"\n--- Run {run + 1}/{num_runs} ---")
+        for ticket in azure_tickets:
+            resp = _process_ticket(ticket=ticket, dry_run=True, config=config, service_now=service_now, llm=llm)
+            results[ticket.number].append(resp)
+            print()
 
     with open(out_file, "w") as f:
-        json.dump([vars(r) for r in all_responses], f, indent=2)
+        json.dump({k: [vars(r) for r in v] for k, v in results.items()}, f, indent=2)

--- a/src/rcpond/llm.py
+++ b/src/rcpond/llm.py
@@ -34,6 +34,10 @@ class LLMResponse:
     """Optional reasoning content (e.g. from models that support chain-of-thought)."""
     planned_tool_call: dict | None = None
     """Optional tool call requested by the model, with arguments parsed from JSON."""
+    ticket_number: str | None = None
+    """The ticket number this response relates to, passed in by the caller."""
+    llm_model: str | None = None
+    """The model identifier used to generate this response."""
 
 
 ## --------------------------------------------------------------------------------
@@ -127,7 +131,12 @@ class LLM:
         )
 
     def generate(
-        self, system_prompt: str, user_prompt: str, model: str, tools: list[Tool] | None = None
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        tools: list[Tool] | None = None,
+        ticket_number: str | None = None,
     ) -> LLMResponse:
         """Generate an LLM response given a system prompt and a user prompt.
         Formats the system and user prompt into a single prompt and calls the `_generate` method to get the response from the LLM.
@@ -143,6 +152,8 @@ class LLM:
             The model to use for generation.
         tools : list[Tool] | None
             Optional list of tools to make available to the model.
+        ticket_number : str | None
+            The ticket number being processed, stored on the response for traceability.
 
         Returns
         -------
@@ -155,4 +166,7 @@ class LLM:
         ]
         tool_dicts = [t.to_openai_dict() for t in tools] if tools else None
         response = self._generate(messages, model=model, tools=tool_dicts)
-        return self._parse_response(response)
+        llm_response = self._parse_response(response)
+        llm_response.ticket_number = ticket_number
+        llm_response.llm_model = model
+        return llm_response

--- a/src/rcpond/parse_html.py
+++ b/src/rcpond/parse_html.py
@@ -23,6 +23,7 @@ are found).
 No configuration is required.
 """
 
+import dataclasses
 from pathlib import Path
 
 import pandas as pd
@@ -377,4 +378,11 @@ def parse_ticket_html(filename: Path) -> FullTicket:
         short_description=_SHORT_DESCRIPTION,
     )
 
-    return FullTicket.from_Ticket(ticket, **facts)
+    ## Filter facts to only the extra fields expected by FullTicket (i.e. those
+    ## not already on Ticket), to avoid passing conflicting keys from extract_key_facts.
+    ticket_field_names = {f.name for f in dataclasses.fields(Ticket)}
+    full_ticket_field_names = {f.name for f in dataclasses.fields(FullTicket)}
+    extra_field_names = full_ticket_field_names - ticket_field_names
+    extra_facts = {k: v for k, v in facts.items() if k in extra_field_names}
+
+    return FullTicket.from_Ticket(ticket, **extra_facts)


### PR DESCRIPTION
This PR:
* Adds a `--num-runs` parameter to the `evaluate-all` subcommand.
* Improves the output format of the `evaluate-all` subcommand to ease post-processing of the results
* Adds a quarto notebook which displays and summarises `evaluate-all` outputs with a ground-truth dataset.
