### PR TITLE
Improve output display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "authlib>=1.3",
     "jinja2>=3.0",
     "requests>=2.32.5",
+    "rich>=13.0",
     "typer>=0.24.1",
     "xdg-base-dirs>=6.0.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rcpond"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name = "James Geddes", email = "jgeddes@turing.ac.uk" },
   { name = "Rosie Wood", email = "rwood@turing.ac.uk"},

--- a/scripts/demo_display_response.py
+++ b/scripts/demo_display_response.py
@@ -1,0 +1,96 @@
+"""Demo script for display_response — shows all three response variants without hitting the LLM."""
+
+from rich.console import Console
+
+from rcpond.display import display_response
+from rcpond.llm import LLMResponse
+
+console = Console()
+
+# ---------------------------------------------------------------------------
+# 1. Freeform note tool call
+# ---------------------------------------------------------------------------
+
+console.rule("[bold]1. post_freeform_note[/bold]")
+
+display_response(
+    LLMResponse(
+        ticket_number="RES0001192",
+        llm_model="gpt-4o",
+        reasoning=(
+            "The request is for an Azure Project subscription renewal. "
+            "Credits requested (£1,210) match the 12-month cost breakdown. "
+            "PI details and finance code are present. Data sensitivity is Public. "
+            "No outstanding queries — I will post an approval note."
+        ),
+        response_text=(
+            "This request is complete and well-justified. " "I will post a freeform approval note to the ticket."
+        ),
+        planned_tool_call={
+            "function": {
+                "name": "post_freeform_note",
+                "arguments": {
+                    "note": (
+                        "Thank you for your request. We have reviewed your Azure allocation "
+                        "request and it has been approved. Your subscription will be renewed "
+                        "shortly. Please contact us if you have any questions."
+                    )
+                },
+            }
+        },
+    ),
+    console=console,
+)
+
+# ---------------------------------------------------------------------------
+# 2. No tool call
+# ---------------------------------------------------------------------------
+
+console.print()
+console.print()
+console.rule("[bold]2. No tool call[/bold]")
+
+display_response(
+    LLMResponse(
+        ticket_number="RES0001193",
+        llm_model="gpt-4o",
+        response_text=(
+            "This request is missing a finance code and the PI email address. "
+            "I cannot approve it without this information. No action taken."
+        ),
+    ),
+    console=console,
+)
+
+# ---------------------------------------------------------------------------
+# 3. Templated note tool call
+# ---------------------------------------------------------------------------
+
+console.print()
+console.print()
+console.rule("[bold]3. post_templated_note[/bold]")
+
+display_response(
+    LLMResponse(
+        ticket_number="RES0001194",
+        llm_model="gpt-4o",
+        reasoning=(
+            "The request is incomplete — the finance code field is blank and no PMU contact "
+            "is listed. I should request the missing information using the standard template."
+        ),
+        response_text=(
+            "The request is missing required finance information. "
+            "I will send the 'missing_information' template to prompt the requestor."
+        ),
+        planned_tool_call={
+            "function": {
+                "name": "post_templated_note",
+                "arguments": {
+                    "template_name": "request_missing_information.yaml.j2",
+                    "missing_fields": "finance code, PMU contact email",
+                },
+            }
+        },
+    ),
+    console=console,
+)

--- a/src/rcpond/command.py
+++ b/src/rcpond/command.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from pprint import pprint
 
 from rcpond.config import Config
+from rcpond.display import display_full_ticket, display_multi_tickets
 from rcpond.llm import LLM, LLMResponse
 from rcpond.prompt import construct_prompt
 from rcpond.servicenow import FullTicket, ServiceNow, Ticket
@@ -80,7 +81,7 @@ def display_all_tickets(include_assigned_tickets: bool, config: Config | None = 
     """Display the list of unassigned tickets from ServiceNow to the user."""
     config = config or Config()
     service_now: ServiceNow = ServiceNow(config)
-    _display_output(service_now.get_tickets(include_assigned_tickets=include_assigned_tickets))
+    display_multi_tickets(service_now.get_tickets(include_assigned_tickets=include_assigned_tickets))
 
 
 def display_single_ticket(ticket_number: str, config: Config | None = None):
@@ -88,7 +89,8 @@ def display_single_ticket(ticket_number: str, config: Config | None = None):
     config = config or Config()
     service_now: ServiceNow = ServiceNow(config)
     ticket = service_now.get_ticket(ticket_number)
-    _display_output(service_now.get_full_ticket(ticket))
+    # _display_output(service_now.get_full_ticket(ticket))
+    display_full_ticket(service_now.get_full_ticket(ticket))
 
 
 def process_next_ticket(dry_run: bool, config: Config | None = None):

--- a/src/rcpond/command.py
+++ b/src/rcpond/command.py
@@ -12,25 +12,13 @@ The four main entry points are:
 
 import json
 from pathlib import Path
-from pprint import pprint
 
 from rcpond.config import Config
-from rcpond.display import display_full_ticket, display_multi_tickets, display_response, display_ticket
+from rcpond.display import display_full_ticket, display_multi_tickets, display_response, display_short_ticket
 from rcpond.llm import LLM, LLMResponse
 from rcpond.prompt import construct_prompt
 from rcpond.servicenow import FullTicket, ServiceNow, Ticket
 from rcpond.tools import get_available_tools
-
-
-def _display_output(*stuff):
-    """
-    Display stuff in a useful way to the user. Precise behaviour TBD.
-
-    Params:
-        stuff: undefined things to display to the user. Precise syntax and structure TBD.
-    """
-
-    pprint(stuff)
 
 
 def _process_ticket(ticket: Ticket, dry_run: bool, config: Config, service_now: ServiceNow, llm: LLM) -> LLMResponse:
@@ -53,13 +41,11 @@ def _process_ticket(ticket: Ticket, dry_run: bool, config: Config, service_now: 
         The LLM client.
     """
     full_ticket: FullTicket = service_now.get_full_ticket(ticket)
-    # print(f"{full_ticket=}")
     tools = get_available_tools(config)
     system_prompt, user_prompt = construct_prompt(full_ticket, config)
     llm_response: LLMResponse = llm.generate(
         system_prompt, user_prompt, config.llm_model, tools=tools, ticket_number=ticket.number
     )
-    # print(f"{llm_response=}")
 
     if not dry_run and llm_response.planned_tool_call is not None:
         name = llm_response.planned_tool_call["function"]["name"]
@@ -89,7 +75,6 @@ def display_single_ticket(ticket_number: str, config: Config | None = None):
     config = config or Config()
     service_now: ServiceNow = ServiceNow(config)
     ticket = service_now.get_ticket(ticket_number)
-    # _display_output(service_now.get_full_ticket(ticket))
     display_full_ticket(service_now.get_full_ticket(ticket))
 
 
@@ -112,7 +97,7 @@ def process_next_ticket(dry_run: bool, config: Config | None = None):
     tickets: list[Ticket] = service_now.get_tickets()
     next_ticket = tickets.pop()
     resp: LLMResponse = _process_ticket(next_ticket, dry_run, config, service_now, llm)
-    display_ticket(next_ticket)
+    display_short_ticket(next_ticket)
     display_response(resp)
 
 
@@ -136,7 +121,7 @@ def process_specific_ticket(ticket_number: str, dry_run: bool, config: Config | 
     llm: LLM = LLM(config)
     ticket = service_now.get_ticket(ticket_number)
     resp: LLMResponse = _process_ticket(ticket, dry_run, config, service_now, llm)
-    display_ticket(ticket)
+    display_short_ticket(ticket)
     display_response(resp)
 
 

--- a/src/rcpond/command.py
+++ b/src/rcpond/command.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from pprint import pprint
 
 from rcpond.config import Config
-from rcpond.display import display_full_ticket, display_multi_tickets
+from rcpond.display import display_full_ticket, display_multi_tickets, display_response, display_ticket
 from rcpond.llm import LLM, LLMResponse
 from rcpond.prompt import construct_prompt
 from rcpond.servicenow import FullTicket, ServiceNow, Ticket
@@ -53,13 +53,13 @@ def _process_ticket(ticket: Ticket, dry_run: bool, config: Config, service_now: 
         The LLM client.
     """
     full_ticket: FullTicket = service_now.get_full_ticket(ticket)
-    print(f"{full_ticket=}")
+    # print(f"{full_ticket=}")
     tools = get_available_tools(config)
     system_prompt, user_prompt = construct_prompt(full_ticket, config)
     llm_response: LLMResponse = llm.generate(
         system_prompt, user_prompt, config.llm_model, tools=tools, ticket_number=ticket.number
     )
-    print(f"{llm_response=}")
+    # print(f"{llm_response=}")
 
     if not dry_run and llm_response.planned_tool_call is not None:
         name = llm_response.planned_tool_call["function"]["name"]
@@ -110,8 +110,10 @@ def process_next_ticket(dry_run: bool, config: Config | None = None):
     service_now: ServiceNow = ServiceNow(config)
     llm: LLM = LLM(config)
     tickets: list[Ticket] = service_now.get_tickets()
-    resp: LLMResponse = _process_ticket(tickets.pop(), dry_run, config, service_now, llm)
-    _display_output(resp)
+    next_ticket = tickets.pop()
+    resp: LLMResponse = _process_ticket(next_ticket, dry_run, config, service_now, llm)
+    display_ticket(next_ticket)
+    display_response(resp)
 
 
 def process_specific_ticket(ticket_number: str, dry_run: bool, config: Config | None = None):
@@ -133,7 +135,9 @@ def process_specific_ticket(ticket_number: str, dry_run: bool, config: Config | 
     service_now: ServiceNow = ServiceNow(config)
     llm: LLM = LLM(config)
     ticket = service_now.get_ticket(ticket_number)
-    _process_ticket(ticket, dry_run, config, service_now, llm)
+    resp: LLMResponse = _process_ticket(ticket, dry_run, config, service_now, llm)
+    display_ticket(ticket)
+    display_response(resp)
 
 
 def batch_process_tickets(dry_run: bool, config: Config | None = None):

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -204,7 +204,7 @@ def display_multi_tickets(tickets: list[Ticket], *, console: Console | None = No
                 ticket.opened_at,
                 ticket.requested_for,
                 ticket.state,
-                ticket.assigned_to if ticket.assigned_to else "UNASSIGNED",
+                ticket.assigned_to if ticket.assigned_to else "[dim]UNASSIGNED[/dim]",
             )
 
         title = f"[bold]{description} / {category}[/bold]"

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -3,7 +3,7 @@
 Provides:
 
 - `display_all_tickets`: Display a grouped summary table of tickets.
-- `display_ticket`: Display a high-level ticket summary.
+- `display_short_ticket`: Display a high-level ticket summary.
 - `display_full_ticket`: Display the full details of a ticket.
 - `display_response`: Display an LLM response.
 """

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -50,6 +50,7 @@ def _header_panel(ticket: Ticket) -> Panel:
             ("Requested by", ticket.requested_for),
             ("Category", f"{ticket.u_category} / {ticket.u_sub_category}"),
             ("Status", ticket.state),
+            ("Assigned to", ticket.assigned_to),
             ("Description", ticket.short_description),
         ]
     )
@@ -192,9 +193,10 @@ def display_multi_tickets(tickets: list[Ticket], *, console: Console | None = No
     for (category, description), group in groups.items():
         table = Table(show_header=True, header_style="bold cyan", box=None, padding=(0, 2))
         table.add_column("Number", no_wrap=True)
-        table.add_column("Opened", no_wrap=True)
+        table.add_column("Opened", no_wrap=False)
         table.add_column("Requested by")
         table.add_column("Status")
+        table.add_column("Assigned To")
 
         for ticket in group:
             table.add_row(
@@ -202,6 +204,7 @@ def display_multi_tickets(tickets: list[Ticket], *, console: Console | None = No
                 ticket.opened_at,
                 ticket.requested_for,
                 ticket.state,
+                ticket.assigned_to if ticket.assigned_to else "UNASSIGNED",
             )
 
         title = f"[bold]{description} / {category}[/bold]"

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -59,7 +59,7 @@ def _header_panel(ticket: Ticket) -> Panel:
     )
 
 
-def display_ticket(ticket: Ticket, *, console: Console | None = None) -> None:
+def display_short_ticket(ticket: Ticket, *, console: Console | None = None) -> None:
     """Display a high-level ticket summary.
 
     Parameters

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -49,6 +49,7 @@ def _header_panel(ticket: Ticket) -> Panel:
             ("Opened", ticket.opened_at),
             ("Requested by", ticket.requested_for),
             ("Category", f"{ticket.u_category} / {ticket.u_sub_category}"),
+            ("Status", ticket.state),
             ("Description", ticket.short_description),
         ]
     )
@@ -200,20 +201,63 @@ def display_multi_tickets(tickets: list[Ticket], *, console: Console | None = No
                 ticket.number,
                 ticket.opened_at,
                 ticket.requested_for,
-                # ticket.u_sub_category,
-                "",  # Pending adding status field
+                ticket.state,
             )
 
         title = f"[bold]{description} / {category}[/bold]"
         con.print(Panel(table, title=title, title_align="left", border_style="bright_blue"))
 
 
-def display_response(response: LLMResponse) -> None:
+def display_response(response: LLMResponse, *, console: Console | None = None) -> None:
     """Display an LLM response.
 
     Parameters
     ----------
     response : LLMResponse
         The response to display.
+    console : Console | None
+        Rich Console to write to. Defaults to the module-level console (stdout).
     """
-    raise NotImplementedError
+    con = console or _console
+
+    title = "[bold]LLM Response[/bold]"
+    if response.ticket_number:
+        title += f"  [dim]{response.ticket_number}[/dim]"
+    if response.llm_model:
+        title += f"  [dim italic]{response.llm_model}[/dim italic]"
+
+    ## Main response text
+    response_text = response.response_text if response.response_text else "NO RESPONSE RECEIVED!"
+    con.print(
+        Panel(
+            Text(response_text, overflow="fold"),
+            title=title,
+            title_align="left",
+            border_style="bright_blue",
+        )
+    )
+
+    ## Reasoning (only present for chain-of-thought models)
+    if response.reasoning:
+        con.print(
+            Panel(
+                Text(response.reasoning, overflow="fold"),
+                title="[bold]Reasoning[/bold]",
+                title_align="left",
+                border_style="dim",
+            )
+        )
+
+    ## Planned tool call
+    if response.planned_tool_call:
+        tool_name = response.planned_tool_call.get("function", {}).get("name", "unknown")
+        args = response.planned_tool_call.get("function", {}).get("arguments", {})
+        rows = list(args.items()) if isinstance(args, dict) else [("arguments", str(args))]
+        con.print(
+            Panel(
+                _kv_table(rows),
+                title=f"[bold]Tool call:[/bold] [cyan]{tool_name}[/cyan]",
+                title_align="left",
+                border_style="yellow",
+            )
+        )

--- a/src/rcpond/display.py
+++ b/src/rcpond/display.py
@@ -1,0 +1,219 @@
+"""Display functions for rcpond output.
+
+Provides:
+
+- `display_all_tickets`: Display a grouped summary table of tickets.
+- `display_ticket`: Display a high-level ticket summary.
+- `display_full_ticket`: Display the full details of a ticket.
+- `display_response`: Display an LLM response.
+"""
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from rcpond.llm import LLMResponse
+from rcpond.servicenow import FullTicket, Ticket
+
+_console = Console()
+
+## --------------------------------------------------------------------------------
+## Internal helpers
+
+
+def _kv_table(rows: list[tuple[str, str]], *, min_col_width: int = 30) -> Table:
+    """Build a two-column key/value table with no visible borders."""
+    table = Table(show_header=False, box=None, padding=(0, 1), min_width=min_col_width)
+    table.add_column(style="bold cyan", no_wrap=True)
+    table.add_column()
+    for key, value in rows:
+        table.add_row(key, value or "[dim]—[/dim]")
+    return table
+
+
+def _section(title: str, rows: list[tuple[str, str]]) -> Panel:
+    """Wrap a key/value table in a titled panel."""
+    return Panel(_kv_table(rows), title=f"[bold]{title}[/bold]", title_align="left", border_style="dim")
+
+
+## --------------------------------------------------------------------------------
+## Public API
+
+
+def _header_panel(ticket: Ticket) -> Panel:
+    """Build the header panel shared by display_ticket and display_full_ticket."""
+    header = _kv_table(
+        [
+            ("Number", ticket.number),
+            ("Opened", ticket.opened_at),
+            ("Requested by", ticket.requested_for),
+            ("Category", f"{ticket.u_category} / {ticket.u_sub_category}"),
+            ("Description", ticket.short_description),
+        ]
+    )
+    return Panel(
+        header, title=f"[bold white]{ticket.number}[/bold white]", title_align="left", border_style="bright_blue"
+    )
+
+
+def display_ticket(ticket: Ticket, *, console: Console | None = None) -> None:
+    """Display a high-level ticket summary.
+
+    Parameters
+    ----------
+    ticket : Ticket
+        The ticket to display.
+    console : Console | None
+        Rich Console to write to. Defaults to the module-level console (stdout).
+    """
+    con = console or _console
+    con.print(_header_panel(ticket))
+
+
+def display_full_ticket(ticket: FullTicket, *, console: Console | None = None) -> None:
+    """Display the full details of a ticket using Rich formatting.
+
+    Parameters
+    ----------
+    ticket : FullTicket
+        The ticket to display.
+    console : Console | None
+        Rich Console to write to. Defaults to the module-level console (stdout).
+    """
+    con = console or _console
+
+    con.print(_header_panel(ticket))
+
+    ## Request details
+    con.print(
+        _section(
+            "Request details",
+            [
+                ("Service", ticket.which_service),
+                ("Subscription type", ticket.subscription_type),
+                ("New / existing", ticket.new_or_existing_allocation),
+                ("Research area", ticket.research_area_programme or ticket.if_other_please_specify),
+                ("Data sensitivity", ticket.data_sensitivity),
+                ("Start date", ticket.start_date),
+                ("End date", ticket.end_date),
+            ],
+        )
+    )
+
+    ## Project
+    con.print(
+        _section(
+            "Project",
+            [
+                ("Project title", ticket.project_title),
+                ("PI / Supervisor", ticket.pi_supervisor_name),
+                ("PI email", ticket.pi_supervisor_email),
+            ],
+        )
+    )
+
+    ## Finance
+    con.print(
+        _section(
+            "Finance",
+            [
+                ("Credits requested", ticket.credits_requested),
+                ("Finance code", ticket.which_finance_code),
+                ("PMU contact email", ticket.pmu_contact_email),
+                ("Subscription / Azure ID", ticket.azure_subscription_id_or_hpc_group_project_id),
+                ("Cost breakdown", ticket.cost_compute_time_breakdown),
+            ],
+        )
+    )
+
+    ## Technical requirements
+    con.print(
+        _section(
+            "Technical requirements",
+            [
+                ("CPU hours", ticket.cpu_hours_required),
+                ("GPU hours", ticket.gpu_hours_required),
+                ("Facility", ticket.which_facility or ticket.if_other_please_specify_facility),
+                ("Computational requirements", ticket.computational_requirements),
+                ("Platform justification", ticket.platform_justification),
+                ("Research justification", ticket.research_justification),
+            ],
+        )
+    )
+
+    ## Access
+    if ticket.users_who_require_access_names_and_emails:
+        con.print(
+            _section(
+                "Users requiring access",
+                [
+                    ("Users", ticket.users_who_require_access_names_and_emails),
+                ],
+            )
+        )
+
+    ## Work notes
+    if ticket.work_notes:
+        con.print(
+            Panel(
+                Text(ticket.work_notes, overflow="fold"),
+                title="[bold]Work notes[/bold]",
+                title_align="left",
+                border_style="dim",
+            )
+        )
+
+
+def display_multi_tickets(tickets: list[Ticket], *, console: Console | None = None) -> None:
+    """Display a table of ticket summaries.
+
+    Each section represents tickets with common values of "Category" and "Description". The Description field is used for the section title.
+
+    Each row represents a single ticket. It should have the columns
+    - Number
+    - Opened date/time
+    - Requested by
+    - Status (new / assigned / on-hold / etc)
+    """
+    con = console or _console
+
+    if not tickets:
+        con.print("[dim]No tickets found.[/dim]")
+        return
+
+    ## Group tickets by (u_category, short_description)
+    groups: dict[tuple[str, str], list[Ticket]] = {}
+    for ticket in tickets:
+        key = (ticket.u_category, ticket.short_description)
+        groups.setdefault(key, []).append(ticket)
+
+    for (category, description), group in groups.items():
+        table = Table(show_header=True, header_style="bold cyan", box=None, padding=(0, 2))
+        table.add_column("Number", no_wrap=True)
+        table.add_column("Opened", no_wrap=True)
+        table.add_column("Requested by")
+        table.add_column("Status")
+
+        for ticket in group:
+            table.add_row(
+                ticket.number,
+                ticket.opened_at,
+                ticket.requested_for,
+                # ticket.u_sub_category,
+                "",  # Pending adding status field
+            )
+
+        title = f"[bold]{description} / {category}[/bold]"
+        con.print(Panel(table, title=title, title_align="left", border_style="bright_blue"))
+
+
+def display_response(response: LLMResponse) -> None:
+    """Display an LLM response.
+
+    Parameters
+    ----------
+    response : LLMResponse
+        The response to display.
+    """
+    raise NotImplementedError

--- a/src/rcpond/parse_html.py
+++ b/src/rcpond/parse_html.py
@@ -377,6 +377,7 @@ def parse_ticket_html(filename: Path) -> FullTicket:
         u_sub_category=facts.get("sub_category") or "",
         short_description=_SHORT_DESCRIPTION,
         state="",
+        assigned_to="",
     )
 
     ## Filter facts to only the extra fields expected by FullTicket (i.e. those

--- a/src/rcpond/parse_html.py
+++ b/src/rcpond/parse_html.py
@@ -376,6 +376,7 @@ def parse_ticket_html(filename: Path) -> FullTicket:
         u_category=facts.get("category") or "",
         u_sub_category=facts.get("sub_category") or "",
         short_description=_SHORT_DESCRIPTION,
+        state="",
     )
 
     ## Filter facts to only the extra fields expected by FullTicket (i.e. those

--- a/src/rcpond/servicenow.py
+++ b/src/rcpond/servicenow.py
@@ -53,6 +53,8 @@ class Ticket:
     short_description: str
     state: str
     """Human-readable ticket state, e.g. 'New', 'In Progress', 'On Hold', 'Resolved', 'Closed'."""
+    assigned_to: str
+    """Display name of the assigned agent, or empty string if unassigned."""
 
 
 @dataclass
@@ -308,6 +310,7 @@ class ServiceNow:
             if new_assignee["display_value"] != "" or new_assignee["value"] != "":
                 err_msg = f"Expected ticket '{ticket.number}' to be unassigned but got: {new_assignee}"
                 raise RuntimeError(err_msg)
+            ticket.assigned_to = ""
             return new_assignee
 
         ## If the assign_to value was not recognised by ServiceNow, then the
@@ -323,6 +326,7 @@ class ServiceNow:
             )
             raise ValueError(err_msg)
 
+        ticket.assigned_to = new_assignee["display_value"]
         return new_assignee
 
 

--- a/src/rcpond/servicenow.py
+++ b/src/rcpond/servicenow.py
@@ -51,6 +51,8 @@ class Ticket:
     u_category: str
     u_sub_category: str
     short_description: str
+    state: str
+    """Human-readable ticket state, e.g. 'New', 'In Progress', 'On Hold', 'Resolved', 'Closed'."""
 
 
 @dataclass

--- a/src/rcpond/tools.py
+++ b/src/rcpond/tools.py
@@ -134,7 +134,6 @@ class PostTemplatedNoteTool(Tool):
         template_name = kwargs.pop("template_name")
         jinja_env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(self._dir)))
         rendered = jinja_env.get_template(template_name).render(ticket=ticket, **kwargs)
-        print(rendered)
         service_now.post_note(ticket, note=rendered)
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -15,7 +15,7 @@ import pytest
 
 from rcpond import command
 from rcpond.config import Config
-from rcpond.servicenow import FullTicket, Ticket
+from rcpond.servicenow import Ticket
 
 
 @pytest.fixture()
@@ -33,6 +33,7 @@ def ticket():
         u_category="HPC",
         u_sub_category="New",
         short_description="Request access to HPC and cloud computing facilities",
+        state="New",
     )
 
 
@@ -58,8 +59,7 @@ def test_display_all_tickets_can_include_assigned(cfg):
 
 def test_display_single_ticket_uses_get_ticket(cfg, ticket):
     """display_single_ticket delegates lookup to get_ticket(), which searches all tickets."""
-    with patch("rcpond.command.ServiceNow") as MockSN:
+    with patch("rcpond.command.ServiceNow") as MockSN, patch("rcpond.command.display_full_ticket"):
         MockSN.return_value.get_ticket.return_value = ticket
-        MockSN.return_value.get_full_ticket.return_value = MagicMock(spec=FullTicket)
         command.display_single_ticket(ticket_number="RES0001000", config=cfg)
     MockSN.return_value.get_ticket.assert_called_once_with("RES0001000")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -34,6 +34,7 @@ def ticket():
         u_sub_category="New",
         short_description="Request access to HPC and cloud computing facilities",
         state="New",
+        assigned_to="",
     )
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,94 @@
+"""Tests for rcpond.display."""
+
+import io
+
+import pytest
+from rich.console import Console
+
+from rcpond.display import display_full_ticket
+from rcpond.servicenow import FullTicket, Ticket
+
+
+@pytest.fixture()
+def full_ticket() -> FullTicket:
+    base = Ticket(
+        sys_id="abc123",
+        number="RES0001000",
+        opened_at="01/01/2026 09:00:00",
+        requested_for="Jane Bloggs",
+        u_category="Research Services",
+        u_sub_category="Research Computing Services",
+        short_description="Request access to HPC and cloud computing facilities",
+    )
+    return FullTicket.from_Ticket(
+        base,
+        work_notes="01/01/2026 09:30:00 - RCP Team (Work notes)\nTicket received.",
+        project_title="Climate Modelling",
+        research_area_programme="Environmental Science",
+        if_other_please_specify="",
+        pi_supervisor_name="Prof. A. Smith",
+        pi_supervisor_email="a.smith@example.ac.uk",
+        which_service="Azure",
+        subscription_type="Project",
+        which_finance_code="ENV-2026-01",
+        pmu_contact_email="pmu@example.ac.uk",
+        credits_requested="5000",
+        which_facility="",
+        if_other_please_specify_facility="",
+        cpu_hours_required="",
+        gpu_hours_required="100",
+        new_or_existing_allocation="New",
+        azure_subscription_id_or_hpc_group_project_id="sub-abc-123",
+        start_date="01/02/2026",
+        end_date="31/01/2027",
+        data_sensitivity="Personal",
+        platform_justification="Azure GPU instances required for model training.",
+        research_justification="High-resolution climate simulations require significant compute.",
+        computational_requirements="V100 GPUs, 100 GPU hours.",
+        users_who_require_access_names_and_emails="jane.bloggs@example.ac.uk",
+        cost_compute_time_breakdown="£500/month for 10 months.",
+    )
+
+
+def _capture(ticket: FullTicket) -> str:
+    """Run display_full_ticket and return the plain-text output."""
+    buf = io.StringIO()
+    con = Console(file=buf, highlight=False, no_color=True)
+    display_full_ticket(ticket, console=con)
+    return buf.getvalue()
+
+
+def test_display_full_ticket_contains_number(full_ticket):
+    assert "RES0001000" in _capture(full_ticket)
+
+
+def test_display_full_ticket_contains_requestor(full_ticket):
+    assert "Jane Bloggs" in _capture(full_ticket)
+
+
+def test_display_full_ticket_contains_project_title(full_ticket):
+    assert "Climate Modelling" in _capture(full_ticket)
+
+
+def test_display_full_ticket_contains_service(full_ticket):
+    assert "Azure" in _capture(full_ticket)
+
+
+def test_display_full_ticket_contains_pi(full_ticket):
+    assert "Prof. A. Smith" in _capture(full_ticket)
+
+
+def test_display_full_ticket_contains_work_notes(full_ticket):
+    assert "Ticket received." in _capture(full_ticket)
+
+
+def test_display_full_ticket_empty_work_notes_omits_section(full_ticket):
+    full_ticket.work_notes = ""
+    output = _capture(full_ticket)
+    assert "Work notes" not in output
+
+
+def test_display_full_ticket_empty_users_omits_section(full_ticket):
+    full_ticket.users_who_require_access_names_and_emails = ""
+    output = _capture(full_ticket)
+    assert "Users requiring access" not in output

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -20,6 +20,7 @@ def full_ticket() -> FullTicket:
         u_sub_category="Research Computing Services",
         short_description="Request access to HPC and cloud computing facilities",
         state="New",
+        assigned_to="",
     )
     return FullTicket.from_Ticket(
         base,

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -19,6 +19,7 @@ def full_ticket() -> FullTicket:
         u_category="Research Services",
         u_sub_category="Research Computing Services",
         short_description="Request access to HPC and cloud computing facilities",
+        state="New",
     )
     return FullTicket.from_Ticket(
         base,

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -58,6 +58,7 @@ def full_ticket():
         u_sub_category="Azure",
         short_description="Request access to HPC and cloud computing facilities",
         state="New",
+        assigned_to="",
         work_notes="",
         project_title="My Project",
         research_area_programme="Health",

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -57,6 +57,7 @@ def full_ticket():
         u_category="Research Computing",
         u_sub_category="Azure",
         short_description="Request access to HPC and cloud computing facilities",
+        state="New",
         work_notes="",
         project_title="My Project",
         research_area_programme="Health",

--- a/tests/test_servicenow.py
+++ b/tests/test_servicenow.py
@@ -28,6 +28,7 @@ def ticket():
         u_sub_category="New",
         short_description="Request access to HPC and cloud computing facilities",
         state="New",
+        assigned_to="",
     )
 
 

--- a/tests/test_servicenow.py
+++ b/tests/test_servicenow.py
@@ -27,6 +27,7 @@ def ticket():
         u_category="HPC",
         u_sub_category="New",
         short_description="Request access to HPC and cloud computing facilities",
+        state="New",
     )
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -40,6 +40,7 @@ def test_post_freeform_note_execute():
         u_sub_category="Azure",
         short_description="Request access",
         state="New",
+        assigned_to="",
     )
     PostFreeformNoteTool().execute(service_now, ticket, note="Please provide more information.")
     service_now.post_note.assert_called_once_with(ticket, note="Please provide more information.")
@@ -81,6 +82,7 @@ def test_post_templated_note_execute_renders_and_posts():
         u_sub_category="Azure",
         short_description="Request access",
         state="New",
+        assigned_to="",
         work_notes="",
         project_title="",
         research_area_programme="",
@@ -158,6 +160,7 @@ def test_call_tool_unknown_tool_raises():
         u_sub_category="Azure",
         short_description="Request access",
         state="New",
+        assigned_to="",
         work_notes="",
         project_title="",
         research_area_programme="",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -39,6 +39,7 @@ def test_post_freeform_note_execute():
         u_category="RC",
         u_sub_category="Azure",
         short_description="Request access",
+        state="New",
     )
     PostFreeformNoteTool().execute(service_now, ticket, note="Please provide more information.")
     service_now.post_note.assert_called_once_with(ticket, note="Please provide more information.")
@@ -79,6 +80,7 @@ def test_post_templated_note_execute_renders_and_posts():
         u_category="RC",
         u_sub_category="Azure",
         short_description="Request access",
+        state="New",
         work_notes="",
         project_title="",
         research_area_programme="",
@@ -155,6 +157,7 @@ def test_call_tool_unknown_tool_raises():
         u_category="RC",
         u_sub_category="Azure",
         short_description="Request access",
+        state="New",
         work_notes="",
         project_title="",
         research_area_programme="",


### PR DESCRIPTION
This PR adds a new module 'display.py'. This provides four new functions:

- `display_all_tickets`: Display a grouped summary table of tickets.
- `display_short_ticket`: Display a high-level ticket summary.
- `display_full_ticket`: Display the full details of a ticket.
- `display_response`: Display an LLM response.

These use [Rich](https://rich.readthedocs.io/en/stable/) to provide intentional CLI displays of `list[Ticket]`, `Ticket`, `FullTicket` and `LLMResponse` objects.

They replace the previous general-purpose stub `def _display_output(*stuff):`.